### PR TITLE
Add support for real client mTLS

### DIFF
--- a/channelz/client.go
+++ b/channelz/client.go
@@ -100,7 +100,7 @@ func (cc *ChannelzClient) findServerByID(ctx context.Context, id int64) *channel
 func (cc *ChannelzClient) DescribeChannel(ctx context.Context, name string) {
 	channel := cc.findTopChannel(ctx, name)
 	if channel == nil {
-		cc.printf("channel %q not found", name)
+		cc.printf("channel %q not found\n", name)
 		return
 	}
 
@@ -188,13 +188,13 @@ func (cc *ChannelzClient) DescribeServerSocket(ctx context.Context, name string)
 	id, err := strconv.ParseInt(name, 10, 64)
 	if err != nil {
 		// TODO: find by name
-		cc.printf("serversocket %q not found", name)
+		cc.printf("serversocket %q not found\n", name)
 		return
 	}
 
 	socket := cc.findSocketByID(ctx, id)
 	if socket == nil {
-		cc.printf("serversocket %q not found", name)
+		cc.printf("serversocket %q not found\n", name)
 		return
 	}
 

--- a/cmd/conn.go
+++ b/cmd/conn.go
@@ -2,18 +2,52 @@ package cmd
 
 import (
 	"context"
-	"time"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
 
-func newGRPCConnection(ctx context.Context, addr string, insecure bool) (*grpc.ClientConn, error) {
+type TLSData struct {
+	CAPool     string
+	ClientCert string
+	ClientKey  string
+}
+
+func newGRPCConnection(ctx context.Context, addr string, insecure bool, tlsData TLSData) (*grpc.ClientConn, error) {
 	var dialOpts []grpc.DialOption
 	if insecure {
 		dialOpts = append(dialOpts, grpc.WithInsecure())
 	} else {
-		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, "")))
+		var ca *x509.CertPool
+		var err error
+		if tlsData.CAPool == "" {
+			ca, err = x509.SystemCertPool()
+			if err != nil {
+				return nil, fmt.Errorf("can't load system cert pool: %v", err)
+			}
+		} else {
+			c, err := os.ReadFile(tlsData.CAPool)
+			if err != nil {
+				return nil, fmt.Errorf("could not read CA from %q: %v", tlsData.CAPool, err)
+			}
+			ca = x509.NewCertPool()
+			if !ca.AppendCertsFromPEM(c) {
+				return nil, fmt.Errorf("could not add CA cert to pool: %v", err)
+			}
+		}
+		cert, err := tls.LoadX509KeyPair(tlsData.ClientCert, tlsData.ClientKey)
+		if err != nil {
+			return nil, fmt.Errorf("can't load client cert: %v", err)
+		}
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+			Certificates: []tls.Certificate{cert},
+			RootCAs:      ca,
+			MinVersion:   tls.VersionTLS13,
+		})))
 	}
 
 	dialOpts = append(dialOpts, grpc.WithBlock(), grpc.WithBackoffMaxDelay(time.Second))

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -45,7 +45,7 @@ func (c *DescribeCommand) Run(cmd *cobra.Command, args []string) error {
 
 	dialCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	conn, err := newGRPCConnection(dialCtx, c.opts.Address, c.opts.Insecure)
+	conn, err := newGRPCConnection(dialCtx, c.opts.Address, c.opts.Insecure, c.opts.TLSData)
 	if err != nil {
 		return fmt.Errorf("failed to connect %v: %v", c.opts.Address, err)
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -44,7 +44,7 @@ func (c *ListCommand) Run(cmd *cobra.Command, args []string) error {
 
 	dialCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	conn, err := newGRPCConnection(dialCtx, c.opts.Address, c.opts.Insecure)
+	conn, err := newGRPCConnection(dialCtx, c.opts.Address, c.opts.Insecure, c.opts.TLSData)
 	if err != nil {
 		return fmt.Errorf("failed to connect %v: %v", c.opts.Address, err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ type GlobalOptions struct {
 	Verbose  bool
 	Address  string
 	Insecure bool
+	TLSData  TLSData
 	Input    io.Reader
 	Output   io.Writer
 }
@@ -36,6 +37,9 @@ func NewRootCommand(r io.Reader, w io.Writer) *RootCommand {
 	c.cmd.PersistentFlags().BoolVarP(&c.opts.Verbose, "verbose", "v", false, "verbose output")
 	c.cmd.PersistentFlags().BoolVarP(&c.opts.Insecure, "insecure", "k", false, "with insecure")
 	c.cmd.PersistentFlags().StringVar(&c.opts.Address, "addr", "", "address to gRPC server")
+	c.cmd.PersistentFlags().StringVar(&c.opts.TLSData.CAPool, "ca-pool", "", "Location of CA pool to load for validating server TLS connections. If blank the system pool will be used.")
+	c.cmd.PersistentFlags().StringVar(&c.opts.TLSData.ClientCert, "client-cert", "", "Location of the certificate to use for client TLS connections.")
+	c.cmd.PersistentFlags().StringVar(&c.opts.TLSData.ClientKey, "client-key", "", "Location of the private key file to use with --client-cert.")
 	c.cmd.AddCommand(NewListCommand(c.opts).Command())
 	c.cmd.AddCommand(NewTreeCommand(c.opts).Command())
 	c.cmd.AddCommand(NewDescribeCommand(c.opts).Command())

--- a/cmd/tree.go
+++ b/cmd/tree.go
@@ -38,7 +38,7 @@ func (c *TreeCommand) Run(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 	typ := args[0]
 
-	conn, err := newGRPCConnection(ctx, c.opts.Address, c.opts.Insecure)
+	conn, err := newGRPCConnection(ctx, c.opts.Address, c.opts.Insecure, c.opts.TLSData)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Allow one to specify a client side cert/key and CAPool to use.

This way one can connect to servers which enforce mTLS with a valid cert as apposed to a self generated one.