### PR TITLE
channelz: print with column alignment

### DIFF
--- a/channelz/client.go
+++ b/channelz/client.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net"
 	"strconv"
+	"text/tabwriter"
 	"time"
 
 	"google.golang.org/grpc"
@@ -19,14 +20,21 @@ var timeNow = time.Now
 
 type ChannelzClient struct {
 	cc channelzpb.ChannelzClient
-	w  io.Writer
+	w  *tabwriter.Writer
 }
 
 func NewClient(conn *grpc.ClientConn, w io.Writer) *ChannelzClient {
 	return &ChannelzClient{
 		cc: channelzpb.NewChannelzClient(conn),
-		w:  w,
+		w:  tabwriter.NewWriter(w, 0, 8, 1, '\t', tabwriter.AlignRight),
 	}
+}
+
+func (cc *ChannelzClient) Flush() error {
+	if cc.w != nil {
+		return cc.w.Flush()
+	}
+	return nil
 }
 
 func (cc *ChannelzClient) printf(format string, a ...interface{}) (n int, err error) {

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -52,6 +52,7 @@ func (c *DescribeCommand) Run(cmd *cobra.Command, args []string) error {
 	defer conn.Close()
 
 	cc := channelz.NewClient(conn, c.opts.Output)
+	defer cc.Flush()
 
 	switch typ {
 	case "channel":

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -51,6 +51,7 @@ func (c *ListCommand) Run(cmd *cobra.Command, args []string) error {
 	defer conn.Close()
 
 	cc := channelz.NewClient(conn, c.opts.Output)
+	defer cc.Flush()
 
 	switch typ {
 	case "channel":

--- a/cmd/tree.go
+++ b/cmd/tree.go
@@ -45,6 +45,7 @@ func (c *TreeCommand) Run(cmd *cobra.Command, args []string) error {
 	defer conn.Close()
 
 	cc := channelz.NewClient(conn, c.opts.Output)
+	defer cc.Flush()
 
 	switch typ {
 	case "channel":


### PR DESCRIPTION
Signed-off-by: Tenhan Lee <tenhanlee@gmail.com>

I love this easy-to-use tool, but the misaligned columns caused by huge value
probably incur misleading at first glance:
```
channelzcli -k --addr localhost:8000 list server                                                                                                                                         ─╯
ID	Name	LocalAddr	Calls	Success	Fail	LastCall
1	<none>	[::]:8000   	171288118	171158184	129933	55ms
```

And this pull request adds column alignment which makes the output clearer:
```
./channelzcli -k --addr localhost:8000 list server                                                                                                                                       ─╯
ID	Name	LocalAddr	Calls		Success		Fail	LastCall
1	<none>	[::]:8000	172694241	172563824	130415	68ms
```