### PR TITLE
support overriding the authority

### DIFF
--- a/cmd/conn.go
+++ b/cmd/conn.go
@@ -18,7 +18,7 @@ type TLSData struct {
 	ClientKey  string
 }
 
-func newGRPCConnection(ctx context.Context, addr string, insecure bool, tlsData TLSData) (*grpc.ClientConn, error) {
+func newGRPCConnection(ctx context.Context, addr string, insecure bool, authority string, tlsData TLSData) (*grpc.ClientConn, error) {
 	var dialOpts []grpc.DialOption
 	if insecure {
 		dialOpts = append(dialOpts, grpc.WithInsecure())
@@ -49,6 +49,10 @@ func newGRPCConnection(ctx context.Context, addr string, insecure bool, tlsData 
 			RootCAs:      ca,
 			MinVersion:   tls.VersionTLS13,
 		})))
+	}
+
+	if authority != "" {
+		dialOpts = append(dialOpts, grpc.WithAuthority(authority))
 	}
 
 	dialOpts = append(dialOpts, grpc.WithBlock(), grpc.WithBackoffMaxDelay(time.Second))

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -45,7 +45,7 @@ func (c *DescribeCommand) Run(cmd *cobra.Command, args []string) error {
 
 	dialCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	conn, err := newGRPCConnection(dialCtx, c.opts.Address, c.opts.Insecure, c.opts.TLSData)
+	conn, err := newGRPCConnection(dialCtx, c.opts.Address, c.opts.Insecure, c.opts.Authority, c.opts.TLSData)
 	if err != nil {
 		return fmt.Errorf("failed to connect %v: %v", c.opts.Address, err)
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -44,7 +44,7 @@ func (c *ListCommand) Run(cmd *cobra.Command, args []string) error {
 
 	dialCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	conn, err := newGRPCConnection(dialCtx, c.opts.Address, c.opts.Insecure, c.opts.TLSData)
+	conn, err := newGRPCConnection(dialCtx, c.opts.Address, c.opts.Insecure, c.opts.Authority, c.opts.TLSData)
 	if err != nil {
 		return fmt.Errorf("failed to connect %v: %v", c.opts.Address, err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,12 +7,13 @@ import (
 )
 
 type GlobalOptions struct {
-	Verbose  bool
-	Address  string
-	Insecure bool
-	TLSData  TLSData
-	Input    io.Reader
-	Output   io.Writer
+	Verbose   bool
+	Address   string
+	Insecure  bool
+	Authority string
+	TLSData   TLSData
+	Input     io.Reader
+	Output    io.Writer
 }
 
 type RootCommand struct {
@@ -37,6 +38,7 @@ func NewRootCommand(r io.Reader, w io.Writer) *RootCommand {
 	c.cmd.PersistentFlags().BoolVarP(&c.opts.Verbose, "verbose", "v", false, "verbose output")
 	c.cmd.PersistentFlags().BoolVarP(&c.opts.Insecure, "insecure", "k", false, "with insecure")
 	c.cmd.PersistentFlags().StringVar(&c.opts.Address, "addr", "", "address to gRPC server")
+	c.cmd.PersistentFlags().StringVar(&c.opts.Authority, "authority", "", "The authoritative name of the remote server. This value is passed as the value of the ':authority' pseudo-header in the HTTP/2 protocol. When TLS is used, this will also be used as the server name when verifying the server's certificate. It defaults to the address that is provided in the positional arguments.")
 	c.cmd.PersistentFlags().StringVar(&c.opts.TLSData.CAPool, "ca-pool", "", "Location of CA pool to load for validating server TLS connections. If blank the system pool will be used.")
 	c.cmd.PersistentFlags().StringVar(&c.opts.TLSData.ClientCert, "client-cert", "", "Location of the certificate to use for client TLS connections.")
 	c.cmd.PersistentFlags().StringVar(&c.opts.TLSData.ClientKey, "client-key", "", "Location of the private key file to use with --client-cert.")

--- a/cmd/tree.go
+++ b/cmd/tree.go
@@ -38,7 +38,7 @@ func (c *TreeCommand) Run(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 	typ := args[0]
 
-	conn, err := newGRPCConnection(ctx, c.opts.Address, c.opts.Insecure, c.opts.TLSData)
+	conn, err := newGRPCConnection(ctx, c.opts.Address, c.opts.Insecure, c.opts.Authority, c.opts.TLSData)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
hey! thanks for creating this library, it's been super helpful. this patch helps in TLS situations where the cert servername name differs from the URL of the service itself.